### PR TITLE
Polish timer layout and improve reset behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# Timer
+
+A lightweight countdown timer built with vanilla HTML, CSS, and JavaScript. It ships with preset durations and simple controls so you can start, pause, and reset a session in a single click.
+
+## Features
+
+- Preset buttons for 1, 2, 3, and 5 minute sessions (customizable in `index.html`).
+- Start/Pause/Reset controls that always resume from the last selected preset.
+- Audible browser alert when the timer completes and automatic restoration of the preset duration so you can quickly begin again.
+
+## Getting started
+
+1. Open `index.html` in any modern browser.
+2. Pick a preset duration or let the default two minute timer stand.
+3. Use **Start** to begin counting down, **Pause** to hold the countdown in place, and **Reset** to jump back to the most recently selected preset.
+
+To adjust the look and feel, edit `style.css`. To change timer behavior, tweak `main.js` or the presets in `index.html`.
+
+## Running tests
+
+This project includes a small test for the shared `formatTime` utility. With Node.js installed, run:
+
+```bash
+npm test
+```
+
+The tests rely on the built-in Node `assert` module, so no additional dependencies are required.

--- a/formatTime.js
+++ b/formatTime.js
@@ -1,0 +1,11 @@
+function formatTime(sec) {
+  const m = String(Math.floor(sec / 60)).padStart(2, '0');
+  const s = String(sec % 60).padStart(2, '0');
+  return `${m}:${s}`;
+}
+
+if (typeof module !== 'undefined') {
+  module.exports = formatTime;
+} else {
+  window.formatTime = formatTime;
+}

--- a/index.html
+++ b/index.html
@@ -8,16 +8,18 @@
 </head>
 <body>
   <div class="presets">
-  <button class="preset" data-seconds="60">1 min</button>
-  <button class="preset" data-seconds="180">3 min</button>
-  <button class="preset" data-seconds="300">5 min</button>
+    <button class="preset" data-seconds="60">1 min</button>
+    <button class="preset" data-seconds="120">2 min</button>
+    <button class="preset" data-seconds="180">3 min</button>
+    <button class="preset" data-seconds="300">5 min</button>
   </div>
-  <div id="display">00.00</div>
-    <div id="controls">
-      <button id="start">Start</button>
-      <button id="pause">Pause</button>
-      <button id="reset">Reset</button>
-    </div>
-    <script src="main.js"></script>
+  <div id="display">02:00</div>
+  <div id="controls">
+    <button id="start">Start</button>
+    <button id="pause">Pause</button>
+    <button id="reset">Reset</button>
+  </div>
+  <script src="formatTime.js"></script>
+  <script src="main.js"></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,19 +1,13 @@
 'use strict';
 
-let totalSeconds = 120;
+let presetSeconds = 120;
+let totalSeconds = presetSeconds;
 let intervalId = null;
 const display = document.getElementById('display');
 const btnStart = document.getElementById('start');
 const btnPause = document.getElementById('pause');
 const btnReset = document.getElementById('reset');
 const presets = document.querySelectorAll('.preset');
-
-
-function formatTime(sec) {
-  const m = String(Math.floor(sec / 60)).padStart(2, '0');
-  const s = String(sec % 60).padStart(2, '0');
-  return `${m}:${s}`;
-}
 
 function updateDisplay() {
   display.textContent = formatTime(totalSeconds);
@@ -25,11 +19,13 @@ function tick() {
     updateDisplay();
   } else {
     clearInterval(intervalId);
+    intervalId = null;
     alert("Time's up!");
+    resetTimer();
   }
 }
 
-function resetTimer(initialSec = 120) {
+function resetTimer(initialSec = presetSeconds) {
   clearInterval(intervalId);
   intervalId = null;
   totalSeconds = initialSec;
@@ -38,13 +34,15 @@ function resetTimer(initialSec = 120) {
 
 presets.forEach(btn => {
   btn.addEventListener('click', () => {
-    const secs = parseInt(btn.dataset.seconds, 10);
-    resetTimer(secs);
+    presetSeconds = parseInt(btn.dataset.seconds, 10);
+    resetTimer(presetSeconds);
   });
 });
 
 btnStart.addEventListener('click', () => {
-  if (intervalId) return;
+  if (intervalId) {
+    return;
+  }
   intervalId = setInterval(tick, 1000);
 });
 
@@ -54,10 +52,7 @@ btnPause.addEventListener('click', () => {
 });
 
 btnReset.addEventListener('click', () => {
-  clearInterval(intervalId);
-  intervalId = null;
-  totalSeconds = 120;
-  updateDisplay();
+  resetTimer();
 });
 
 updateDisplay();

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "timer",
+  "version": "1.0.0",
+  "scripts": {
+    "test": "node test/formatTime.test.js"
+  }
+}

--- a/style.css
+++ b/style.css
@@ -1,7 +1,7 @@
 body {
   font-family: Arial, Helvetica, sans-serif;
   display: flex;
-  flex-direction: flex;
+  flex-direction: column;
   align-items: center;
   margin-top: 50px;
 }
@@ -11,13 +11,16 @@ body {
   margin: 0 20px;
 }
 
-.controls, .presets {
+#controls,
+.presets {
   margin-bottom: 10px;
+  display: flex;
+  justify-content: center;
 }
 
 button {
   padding: 10px 20px;
-  margin: 0 5px 0 20px;
+  margin: 0 10px;
   font-size: 16px;
   cursor: pointer;
 }
@@ -30,6 +33,7 @@ button {
 button:hover {
   background-color: #f0f0f0;
 }
+
 button:active {
   background-color: #ef8a8a;
 }

--- a/test/formatTime.test.js
+++ b/test/formatTime.test.js
@@ -1,0 +1,9 @@
+const assert = require('assert');
+const formatTime = require('../formatTime');
+
+assert.strictEqual(formatTime(0), '00:00');
+assert.strictEqual(formatTime(65), '01:05');
+assert.strictEqual(formatTime(3599), '59:59');
+
+console.log('All tests passed.');
+


### PR DESCRIPTION
## Summary
- update the timer UI markup and styles so the controls align and include a 2-minute preset
- ensure the timer resets to the last preset and can start again after finishing
- expand the README with feature highlights, usage steps, and testing notes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6842b9d757348325a1532a47588a1a3a